### PR TITLE
Spet 2021: Update 1 - Mote Mappings

### DIFF
--- a/Mote-Mappings.lua
+++ b/Mote-Mappings.lua
@@ -11,62 +11,90 @@ elements = {}
 
 elements.list = S{'Light','Dark','Fire','Ice','Wind','Earth','Lightning','Water'}
 
-elements.weak_to = {['Light']='Dark', ['Dark']='Light', ['Fire']='Ice', ['Ice']='Wind', ['Wind']='Earth', ['Earth']='Lightning',
-        ['Lightning']='Water', ['Water']='Fire'}
+elements.weak_to = {
+    ['Light'] = 'Dark', ['Dark'] = 'Light', ['Fire'] = 'Ice', ['Ice'] = 'Wind',
+    ['Wind'] = 'Earth', ['Earth'] = 'Lightning', ['Lightning'] = 'Water', ['Water'] = 'Fire'
+}
 
-elements.strong_to = {['Light']='Dark', ['Dark']='Light', ['Fire']='Water', ['Ice']='Fire', ['Wind']='Ice', ['Earth']='Wind',
-        ['Lightning']='Earth', ['Water']='Lightning'}
+elements.strong_to = {
+    ['Light'] = 'Dark', ['Dark'] = 'Light', ['Fire'] = 'Water', ['Ice'] = 'Fire',
+    ['Wind'] = 'Ice', ['Earth'] = 'Wind', ['Lightning'] = 'Earth', ['Water'] = 'Lightning'
+}
 
-storms = S{"Aurorastorm", "Voidstorm", "Firestorm", "Sandstorm", "Rainstorm", "Windstorm", "Hailstorm", "Thunderstorm",
-        "Aurorastorm II", "Voidstorm II", "Firestorm II", "Sandstorm II", "Rainstorm II", "Windstorm II", "Hailstorm II", "Thunderstorm II"}
+storms = S{
+    "Aurorastorm",    "Voidstorm",    "Firestorm",    "Sandstorm",    "Rainstorm",    "Windstorm",    "Hailstorm",    "Thunderstorm",
+    "Aurorastorm II", "Voidstorm II", "Firestorm II", "Sandstorm II", "Rainstorm II", "Windstorm II", "Hailstorm II", "Thunderstorm II"
+}
 
-elements.storm_of = {['Light']="Aurorastorm", ['Dark']="Voidstorm", ['Fire']="Firestorm", ['Earth']="Sandstorm",
-        ['Water']="Rainstorm", ['Wind']="Windstorm", ['Ice']="Hailstorm", ['Lightning']="Thunderstorm",['Light']="Aurorastorm II",
-        ['Dark']="Voidstorm II", ['Fire']="Firestorm II", ['Earth']="Sandstorm II", ['Water']="Rainstorm II", ['Wind']="Windstorm II",
-        ['Ice']="Hailstorm II", ['Lightning']="Thunderstorm II"}
+elements.storm_of = {
+    ['Light'] = "Aurorastorm", ['Dark'] = "Voidstorm", ['Fire'] = "Firestorm", ['Earth'] = "Sandstorm",['Water'] = "Rainstorm", ['Wind'] = "Windstorm", ['Ice'] = "Hailstorm", ['Lightning'] = "Thunderstorm",
+    ['Light'] = "Aurorastorm II",['Dark'] = "Voidstorm II", ['Fire'] = "Firestorm II", ['Earth'] = "Sandstorm II", ['Water'] = "Rainstorm II", ['Wind'] = "Windstorm II",['Ice'] = "Hailstorm II", ['Lightning'] = "Thunderstorm II"
+}
 
 spirits = S{"LightSpirit", "DarkSpirit", "FireSpirit", "EarthSpirit", "WaterSpirit", "AirSpirit", "IceSpirit", "ThunderSpirit"}
-elements.spirit_of = {['Light']="Light Spirit", ['Dark']="Dark Spirit", ['Fire']="Fire Spirit", ['Earth']="Earth Spirit",
-        ['Water']="Water Spirit", ['Wind']="Air Spirit", ['Ice']="Ice Spirit", ['Lightning']="Thunder Spirit"}
+elements.spirit_of = {
+    ['Light'] = "Light Spirit",
+    ['Dark'] = "Dark Spirit",
+    ['Fire'] = "Fire Spirit",
+    ['Earth'] = "Earth Spirit",
+    ['Water'] = "Water Spirit",
+    ['Wind'] = "Air Spirit",
+    ['Ice'] = "Ice Spirit",
+    ['Lightning'] = "Thunder Spirit"
+}
 
 runes = S{'Lux', 'Tenebrae', 'Ignis', 'Gelus', 'Flabra', 'Tellus', 'Sulpor', 'Unda'}
-elements.rune_of = {['Light']='Lux', ['Dark']='Tenebrae', ['Fire']='Ignis', ['Ice']='Gelus', ['Wind']='Flabra',
-     ['Earth']='Tellus', ['Lightning']='Sulpor', ['Water']='Unda'}
+elements.rune_of = {
+    ['Light'] = 'Lux', ['Dark'] = 'Tenebrae', ['Fire'] = 'Ignis', ['Ice'] = 'Gelus',
+    ['Wind'] = 'Flabra', ['Earth'] = 'Tellus', ['Lightning'] = 'Sulpor', ['Water'] = 'Unda'
+}
 
-elements.obi_of = {['Light']='Hachirin-no-obi', ['Dark']='Hachirin-no-obi', ['Fire']='Hachirin-no-obi', ['Ice']='Hachirin-no-obi', ['Wind']='Hachirin-no-obi',
-     ['Earth']='Hachirin-no-obi', ['Lightning']='Hachirin-no-obi', ['Water']='Hachirin-no-obi'}
+elements.obi_of = {
+    ['Light'] = 'Hachirin-no-obi', ['Dark'] = 'Hachirin-no-obi', ['Fire'] = 'Hachirin-no-obi', ['Ice'] = 'Hachirin-no-obi',
+    ['Wind'] = 'Hachirin-no-obi', ['Earth'] = 'Hachirin-no-obi', ['Lightning'] = 'Hachirin-no-obi', ['Water'] = 'Hachirin-no-obi'
+}
 
-elements.gorget_of = {['Light']='Fotia Gorget', ['Dark']='Fotia Gorget', ['Fire']='Fotia Gorget', ['Ice']='Fotia Gorget',
-    ['Wind']='Fotia Gorget', ['Earth']='Fotia Gorget', ['Lightning']='Fotia Gorget', ['Water']='Fotia Gorget'}
+elements.gorget_of = {
+    ['Light'] = 'Fotia Gorget', ['Dark'] = 'Fotia Gorget', ['Fire'] = 'Fotia Gorget', ['Ice'] = 'Fotia Gorget',
+    ['Wind'] = 'Fotia Gorget', ['Earth'] = 'Fotia Gorget', ['Lightning'] = 'Fotia Gorget', ['Water'] = 'Fotia Gorget'
+}
 
-elements.belt_of = {['Light']='Fotia Belt', ['Dark']='Fotia Belt', ['Fire']='Fotia Belt', ['Ice']='Fotia Belt',
-    ['Wind']='Fotia Belt', ['Earth']='Fotia Belt', ['Lightning']='Fotia Belt', ['Water']='Fotia Belt'}
+elements.belt_of = {
+    ['Light'] = 'Fotia Belt', ['Dark'] = 'Fotia Belt', ['Fire'] = 'Fotia Belt', ['Ice'] = 'Fotia Belt',
+    ['Wind'] = 'Fotia Belt', ['Earth'] = 'Fotia Belt', ['Lightning'] = 'Fotia Belt', ['Water'] = 'Fotia Belt'
+}
 
-elements.fastcast_staff_of = {['Light']='Arka I', ['Dark']='Xsaeta I', ['Fire']='Atar I', ['Ice']='Vourukasha I',
-    ['Wind']='Vayuvata I', ['Earth']='Vishrava I', ['Lightning']='Apamajas I', ['Water']='Haoma I', ['Thunder']='Apamajas I'}
+elements.fastcast_staff_of = {
+    ['Light'] = 'Arka I', ['Dark'] = 'Xsaeta I', ['Fire'] = 'Atar I', ['Ice'] = 'Vourukasha I', ['Wind'] = 'Vayuvata I',
+    ['Earth'] = 'Vishrava I', ['Lightning'] = 'Apamajas I', ['Water'] = 'Haoma I', ['Thunder'] = 'Apamajas I'
+}
 
-elements.recast_staff_of = {['Light']='Arka II', ['Dark']='Xsaeta II', ['Fire']='Atar II', ['Ice']='Vourukasha II',
-    ['Wind']='Vayuvata II', ['Earth']='Vishrava II', ['Lightning']='Apamajas II', ['Water']='Haoma II', ['Thunder']='Apamajas II'}
+elements.recast_staff_of = {
+    ['Light'] = 'Arka II', ['Dark'] = 'Xsaeta II', ['Fire'] = 'Atar II', ['Ice'] = 'Vourukasha II', ['Wind'] = 'Vayuvata II',
+    ['Earth'] = 'Vishrava II', ['Lightning'] = 'Apamajas II', ['Water'] = 'Haoma II', ['Thunder'] = 'Apamajas II'
+}
 
-elements.perpetuance_staff_of = {['Light']='Arka III', ['Dark']='Xsaeta III', ['Fire']='Atar III', ['Ice']='Vourukasha III',
-    ['Wind']='Vayuvata III', ['Earth']='Vishrava III', ['Lightning']='Apamajas III', ['Water']='Haoma III', ['Thunder']='Apamajas III'}
+elements.perpetuance_staff_of = {
+    ['Light'] = 'Arka III', ['Dark'] = 'Xsaeta III', ['Fire'] = 'Atar III', ['Ice'] = 'Vourukasha III', ['Wind'] = 'Vayuvata III',
+    ['Earth'] = 'Vishrava III', ['Lightning'] = 'Apamajas III', ['Water'] = 'Haoma III', ['Thunder'] = 'Apamajas III'
+}
 
 
 -- Elements for skillchain names
 skillchain_elements = {}
-skillchain_elements.Light = S{'Light','Fire','Wind','Lightning'}
-skillchain_elements.Darkness = S{'Dark','Ice','Earth','Water'}
-skillchain_elements.Fusion = S{'Light','Fire'}
+skillchain_elements.Light         = S{'Light','Fire','Wind','Lightning'}
+skillchain_elements.Darkness      = S{'Dark','Ice','Earth','Water'}
+skillchain_elements.Fusion        = S{'Light','Fire'}
 skillchain_elements.Fragmentation = S{'Wind','Lightning'}
-skillchain_elements.Distortion = S{'Ice','Water'}
-skillchain_elements.Gravitation = S{'Dark','Earth'}
-skillchain_elements.Transfixion = S{'Light'}
-skillchain_elements.Compression = S{'Dark'}
+skillchain_elements.Distortion    = S{'Ice','Water'}
+skillchain_elements.Gravitation   = S{'Dark','Earth'}
+skillchain_elements.Transfixion   = S{'Light'}
+skillchain_elements.Compression   = S{'Dark'}
 skillchain_elements.Liquification = S{'Fire'}
-skillchain_elements.Induration = S{'Ice'}
-skillchain_elements.Detonation = S{'Wind'}
-skillchain_elements.Scission = S{'Earth'}
-skillchain_elements.Impaction = S{'Lightning'}
+skillchain_elements.Induration    = S{'Ice'}
+skillchain_elements.Detonation    = S{'Wind'}
+skillchain_elements.Scission      = S{'Earth'}
+skillchain_elements.Impaction     = S{'Lightning'}
 skillchain_elements.Reverberation = S{'Water'}
 
 
@@ -78,67 +106,74 @@ skillchain_elements.Reverberation = S{'Water'}
 data = {}
 data.weaponskills = {}
 data.weaponskills.relic = {
-    ["Spharai"] = "Final Heaven",
-    ["Mandau"] = "Mercy Stroke",
-    ["Excalibur"] = "Knights of Round",
-    ["Ragnarok"] = "Scourge",
-    ["Guttler"] = "Onslaught",
-    ["Bravura"] = "Metatron Torment",
-    ["Apocalypse"] = "Catastrophe",
-    ["Gungnir"] = "Gierskogul",
-    ["Kikoku"] = "Blade: Metsu",
+    ["Spharai"]       = "Final Heaven",
+    ["Mandau"]        = "Mercy Stroke",
+    ["Excalibur"]     = "Knights of Round",
+    ["Ragnarok"]      = "Scourge",
+    ["Guttler"]       = "Onslaught",
+    ["Bravura"]       = "Metatron Torment",
+    ["Apocalypse"]    = "Catastrophe",
+    ["Gungnir"]       = "Gierskogul",
+    ["Kikoku"]        = "Blade: Metsu",
     ["Amanomurakumo"] = "Tachi: Kaiten",
-    ["Mjollnir"] = "Randgrith",
-    ["Claustrum"] = "Gates of Tartarus",
-    ["Annihilator"] = "Coronach",
-    ["Yoichinoyumi"] = "Namas Arrow"}
+    ["Mjollnir"]      = "Randgrith",
+    ["Claustrum"]     = "Gates of Tartarus",
+    ["Annihilator"]   = "Coronach",
+    ["Yoichinoyumi"]  = "Namas Arrow"
+}
+
 data.weaponskills.mythic = {
-    ["Conqueror"] = "King's Justice",
-    ["Glanzfaust"] = "Ascetic's Fury",
-    ["Yagrush"] = "Mystic Boon",
-    ["Laevateinn"] = "Vidohunir",
-    ["Murgleis"] = "Death Blossom",
-    ["Vajra"] = "Mandalic Stab",
-    ["Burtgang"] = "Atonement",
-    ["Liberator"] = "Insurgency",
-    ["Aymur"] = "Primal Rend",
-    ["Carnwenhan"] = "Mordant Rime",
-    ["Gastraphetes"] = "Trueflight",
-    ["Kogarasumaru"] = "Tachi: Rana",
-    ["Nagi"] = "Blade: Kamu",
-    ["Ryunohige"] = "Drakesbane",
-    ["Nirvana"] = "Garland of Bliss",
-    ["Tizona"] = "Expiacion",
+    ["Conqueror"]     = "King's Justice",
+    ["Glanzfaust"]    = "Ascetic's Fury",
+    ["Yagrush"]       = "Mystic Boon",
+    ["Laevateinn"]    = "Vidohunir",
+    ["Murgleis"]      = "Death Blossom",
+    ["Vajra"]         = "Mandalic Stab",
+    ["Burtgang"]      = "Atonement",
+    ["Liberator"]     = "Insurgency",
+    ["Aymur"]         = "Primal Rend",
+    ["Carnwenhan"]    = "Mordant Rime",
+    ["Gastraphetes"]  = "Trueflight",
+    ["Kogarasumaru"]  = "Tachi: Rana",
+    ["Nagi"]          = "Blade: Kamu",
+    ["Ryunohige"]     = "Drakesbane",
+    ["Nirvana"]       = "Garland of Bliss",
+    ["Tizona"]        = "Expiacion",
     ["Death Penalty"] = "Leaden Salute",
-    ["Kenkonken"] = "Stringing Pummel",
-    ["Terpsichore"] = "Pyrrhic Kleos",
-    ["Tupsimati"] = "Omniscience",
-    ["Idris"] = "Exudation",
-    ["Epeolatry"] = "Dimidiation"}
+    ["Kenkonken"]     = "Stringing Pummel",
+    ["Terpsichore"]   = "Pyrrhic Kleos",
+    ["Tupsimati"]     = "Omniscience",
+    ["Idris"]         = "Exudation",
+    ["Epeolatry"]     = "Dimidiation"
+}
+
 data.weaponskills.empyrean = {
     ["Verethragna"] = "Victory Smite",
-    ["Twashtar"] = "Rudra's Storm",
-    ["Almace"] = "Chant du Cygne",
-    ["Caladbolg"] = "Torcleaver",
-    ["Farsha"] = "Cloudsplitter",
-    ["Ukonvasara"] = "Ukko's Fury",
-    ["Redemption"] = "Quietus",
+    ["Twashtar"]    = "Rudra's Storm",
+    ["Almace"]      = "Chant du Cygne",
+    ["Caladbolg"]   = "Torcleaver",
+    ["Farsha"]      = "Cloudsplitter",
+    ["Ukonvasara"]  = "Ukko's Fury",
+    ["Redemption"]  = "Quietus",
     ["Rhongomiant"] = "Camlann's Torment",
-    ["Kannagi"] = "Blade: Hi",
-    ["Masamune"] = "Tachi: Fudo",
+    ["Kannagi"]     = "Blade: Hi",
+    ["Masamune"]    = "Tachi: Fudo",
     ["Gambanteinn"] = "Dagann",
-    ["Hvergelmir"] = "Myrkr",
-    ["Gandiva"] = "Jishnu's Radiance",
-    ["Armageddon"] = "Wildfire"}
+    ["Hvergelmir"]  = "Myrkr",
+    ["Gandiva"]     = "Jishnu's Radiance",
+    ["Armageddon"]  = "Wildfire"
+}
 
 -- Weaponskills that can be used at range.
-data.weaponskills.ranged = S{"Flaming Arrow", "Piercing Arrow", "Dulling Arrow", "Sidewinder", "Arching Arrow",
+data.weaponskills.ranged = S{
+    "Flaming Arrow", "Piercing Arrow", "Dulling Arrow", "Sidewinder", "Arching Arrow",
     "Empyreal Arrow", "Refulgent Arrow", "Apex Arrow", "Namas Arrow", "Jishnu's Radiance",
     "Hot Shot", "Split Shot", "Sniper Shot", "Slug Shot", "Heavy Shot", "Detonator", "Last Stand",
-    "Coronach", "Trueflight", "Leaden Salute", "Wildfire",
-    "Myrkr"}
+    "Coronach", "Trueflight", "Leaden Salute", "Wildfire", "Myrkr"
+}
 
 ranged_weaponskills = data.weaponskills.ranged
+
 
 -------------------------------------------------------------------------------------------------------------------
 -- Spell mappings allow defining a general category or description that each of sets of related
@@ -146,66 +181,104 @@ ranged_weaponskills = data.weaponskills.ranged
 -------------------------------------------------------------------------------------------------------------------
 
 spell_maps = {
-    ['Cure']='Cure',['Cure II']='Cure',['Cure III']='Cure',['Cure IV']='Cure',['Cure V']='Cure',['Cure VI']='Cure',
-    ['Full Cure']='Cure',
-    ['Cura']='Curaga',['Cura II']='Curaga',['Cura III']='Curaga',
-    ['Curaga']='Curaga',['Curaga II']='Curaga',['Curaga III']='Curaga',['Curaga IV']='Curaga',['Curaga V']='Curaga',
-    -- Status Removal doesn't include Esuna or Sacrifice, since they work differently than the rest
-    ['Poisona']='StatusRemoval',['Paralyna']='StatusRemoval',['Silena']='StatusRemoval',['Blindna']='StatusRemoval',['Cursna']='StatusRemoval',
-    ['Stona']='StatusRemoval',['Viruna']='StatusRemoval',['Erase']='StatusRemoval',
-    ['Barfire']='BarElement',['Barstone']='BarElement',['Barwater']='BarElement',['Baraero']='BarElement',['Barblizzard']='BarElement',['Barthunder']='BarElement',
-    ['Barfira']='BarElement',['Barstonra']='BarElement',['Barwatera']='BarElement',['Baraera']='BarElement',['Barblizzara']='BarElement',['Barthundra']='BarElement',
-    ['Raise']='Raise',['Raise II']='Raise',['Raise III']='Raise',['Arise']='Raise',
-    ['Reraise']='Reraise',['Reraise II']='Reraise',['Reraise III']='Reraise',['Reraise IV']='Reraise',
-    ['Protect']='Protect',['Protect II']='Protect',['Protect III']='Protect',['Protect IV']='Protect',['Protect V']='Protect',
-    ['Shell']='Shell',['Shell II']='Shell',['Shell III']='Shell',['Shell IV']='Shell',['Shell V']='Shell',
-    ['Protectra']='Protectra',['Protectra II']='Protectra',['Protectra III']='Protectra',['Protectra IV']='Protectra',['Protectra V']='Protectra',
-    ['Shellra']='Shellra',['Shellra II']='Shellra',['Shellra III']='Shellra',['Shellra IV']='Shellra',['Shellra V']='Shellra',
-    ['Regen']='Regen',['Regen II']='Regen',['Regen III']='Regen',['Regen IV']='Regen',['Regen V']='Regen',
-    ['Refresh']='Refresh',['Refresh II']='Refresh',['Refresh III']='Refresh',
-    ['Teleport-Holla']='Teleport',['Teleport-Dem']='Teleport',['Teleport-Mea']='Teleport',['Teleport-Altep']='Teleport',['Teleport-Yhoat']='Teleport',
-    ['Teleport-Vahzl']='Teleport',['Recall-Pashh']='Teleport',['Recall-Meriph']='Teleport',['Recall-Jugner']='Teleport',
-    ['Valor Minuet']='Minuet',['Valor Minuet II']='Minuet',['Valor Minuet III']='Minuet',['Valor Minuet IV']='Minuet',['Valor Minuet V']='Minuet',
-    ["Knight's Minne"]='Minne',["Knight's Minne II"]='Minne',["Knight's Minne III"]='Minne',["Knight's Minne IV"]='Minne',["Knight's Minne V"]='Minne',
-    ['Advancing March']='March',['Victory March']='March',
-    ['Sword Madrigal']='Madrigal',['Blade Madrigal']='Madrigal',
-    ["Hunter's Prelude"]='Prelude',["Archer's Prelude"]='Prelude',
-    ['Sheepfoe Mambo']='Mambo',['Dragonfoe Mambo']='Mambo',
-    ['Raptor Mazurka']='Mazurka',['Chocobo Mazurka']='Mazurka',
-    ['Sinewy Etude']='Etude',['Dextrous Etude']='Etude',['Vivacious Etude']='Etude',['Quick Etude']='Etude',['Learned Etude']='Etude',['Spirited Etude']='Etude',['Enchanting Etude']='Etude',
-    ['Herculean Etude']='Etude',['Uncanny Etude']='Etude',['Vital Etude']='Etude',['Swift Etude']='Etude',['Sage Etude']='Etude',['Logical Etude']='Etude',['Bewitching Etude']='Etude',
-    ["Mage's Ballad"]='Ballad',["Mage's Ballad II"]='Ballad',["Mage's Ballad III"]='Ballad',
-    ["Army's Paeon"]='Paeon',["Army's Paeon II"]='Paeon',["Army's Paeon III"]='Paeon',["Army's Paeon IV"]='Paeon',["Army's Paeon V"]='Paeon',["Army's Paeon VI"]='Paeon',
-    ['Fire Carol']='Carol',['Ice Carol']='Carol',['Wind Carol']='Carol',['Earth Carol']='Carol',['Lightning Carol']='Carol',['Water Carol']='Carol',['Light Carol']='Carol',['Dark Carol']='Carol',
-    ['Fire Carol II']='Carol',['Ice Carol II']='Carol',['Wind Carol II']='Carol',['Earth Carol II']='Carol',['Lightning Carol II']='Carol',['Water Carol II']='Carol',['Light Carol II']='Carol',['Dark Carol II']='Carol',
-    ['Foe Lullaby']='Lullaby',['Foe Lullaby II']='Lullaby',['Horde Lullaby']='Lullaby',['Horde Lullaby II']='Lullaby',
-    ['Fire Threnody']='Threnody',['Ice Threnody']='Threnody',['Wind Threnody']='Threnody',['Earth Threnody']='Threnody',['Lightning Threnody']='Threnody',['Water Threnody']='Threnody',['Light Threnody']='Threnody',['Dark Threnody']='Threnody',
-    ['Fire Threnody II']='Threnody',['Ice Threnody II']='Threnody',['Wind Threnody II']='Threnody',['Earth Threnody II']='Threnody',['Lightning Threnody II']='Threnody',['Water Threnody II']='Threnody',['Light Threnody II']='Threnody',['Dark Threnody II']='Threnody',
-    ['Battlefield Elegy']='Elegy',['Carnage Elegy']='Elegy',
-    ['Foe Requiem']='Requiem',['Foe Requiem II']='Requiem',['Foe Requiem III']='Requiem',['Foe Requiem IV']='Requiem',['Foe Requiem V']='Requiem',['Foe Requiem VI']='Requiem',['Foe Requiem VII']='Requiem',
-    ['Utsusemi: Ichi']='Utsusemi',['Utsusemi: Ni']='Utsusemi',['Utsusemi: San']='Utsusemi',
-    ['Katon: Ichi'] = 'ElementalNinjutsu',['Suiton: Ichi'] = 'ElementalNinjutsu',['Raiton: Ichi'] = 'ElementalNinjutsu',
-    ['Doton: Ichi'] = 'ElementalNinjutsu',['Huton: Ichi'] = 'ElementalNinjutsu',['Hyoton: Ichi'] = 'ElementalNinjutsu',
-    ['Katon: Ni'] = 'ElementalNinjutsu',['Suiton: Ni'] = 'ElementalNinjutsu',['Raiton: Ni'] = 'ElementalNinjutsu',
-    ['Doton: Ni'] = 'ElementalNinjutsu',['Huton: Ni'] = 'ElementalNinjutsu',['Hyoton: Ni'] = 'ElementalNinjutsu',
-    ['Katon: San'] = 'ElementalNinjutsu',['Suiton: San'] = 'ElementalNinjutsu',['Raiton: San'] = 'ElementalNinjutsu',
-    ['Doton: San'] = 'ElementalNinjutsu',['Huton: San'] = 'ElementalNinjutsu',['Hyoton: San'] = 'ElementalNinjutsu',
-    ['Banish']='Banish',['Banish II']='Banish',['Banish III']='Banish',['Banishga']='Banish',['Banishga II']='Banish',
-    ['Holy']='Holy',['Holy II']='Holy',['Drain']='Drain',['Drain II']='Drain',['Drain III']='Drain',['Aspir']='Aspir',['Aspir II']='Aspir',
-    ['Absorb-Str']='Absorb',['Absorb-Dex']='Absorb',['Absorb-Vit']='Absorb',['Absorb-Agi']='Absorb',['Absorb-Int']='Absorb',['Absorb-Mnd']='Absorb',['Absorb-Chr']='Absorb',
-    ['Absorb-Acc']='Absorb',['Absorb-TP']='Absorb',['Absorb-Attri']='Absorb',
-    ['Enlight']='Enlight',['Enlight II']='Enlight',['Endark']='Endark',['Endark II']='Endark',
-    ['Burn']='ElementalEnfeeble',['Frost']='ElementalEnfeeble',['Choke']='ElementalEnfeeble',['Rasp']='ElementalEnfeeble',['Shock']='ElementalEnfeeble',['Drown']='ElementalEnfeeble',
-    ['Pyrohelix']='Helix',['Cryohelix']='Helix',['Anemohelix']='Helix',['Geohelix']='Helix',['Ionohelix']='Helix',['Hydrohelix']='Helix',['Luminohelix']='Helix',['Noctohelix']='Helix',
-    ['Pyrohelix II']='Helix',['Cryohelix II']='Helix',['Anemohelix II']='Helix',['Geohelix II']='Helix',['Ionohelix II']='Helix',['Hydrohelix II']='Helix',['Luminohelix II']='Helix',['Noctohelix II']='Helix',
-    ['Firestorm']='Storm',['Hailstorm']='Storm',['Windstorm']='Storm',['Sandstorm']='Storm',['Thunderstorm']='Storm',['Rainstorm']='Storm',['Aurorastorm']='Storm',['Voidstorm']='Storm',
-    ['Firestorm II']='Storm',['Hailstorm II']='Storm',['Windstorm II']='Storm',['Sandstorm II']='Storm',['Thunderstorm II']='Storm',['Rainstorm II']='Storm',['Aurorastorm II']='Storm',['Voidstorm II']='Storm',
-    ['Fire Maneuver']='Maneuver',['Ice Maneuver']='Maneuver',['Wind Maneuver']='Maneuver',['Earth Maneuver']='Maneuver',['Thunder Maneuver']='Maneuver',
-    ['Water Maneuver']='Maneuver',['Light Maneuver']='Maneuver',['Dark Maneuver']='Maneuver',
+    --  Dark Magic
+    ['Absorb-Str'] = 'Absorb', ['Absorb-Dex'] = 'Absorb', ['Absorb-Vit'] = 'Absorb', ['Absorb-Agi'] = 'Absorb', ['Absorb-Int'] = 'Absorb', ['Absorb-Mnd'] = 'Absorb', ['Absorb-Chr'] = 'Absorb',
+    ['Absorb-Acc'] = 'Absorb', ['Absorb-TP'] = 'Absorb', ['Absorb-Attri'] = 'Absorb',
+    ['Aspir'] = 'Aspir', ['Aspir II'] = 'Aspir',
+    ['Bio'] = 'Bio', ['Bio II'] = 'Bio', ['Bio III'] = 'Bio',
+    ['Drain'] = 'Drain', ['Drain II'] = 'Drain', ['Drain III'] = 'Drain',
+    ['Endark'] = 'Endark', ['Endark II'] = 'Endark',
+    --  Divine Magic
+    ['Banish'] = 'Banish', ['Banish II'] = 'Banish', ['Banish III'] = 'Banish',
+    ['Banishga'] = 'Banish', ['Banishga II'] = 'Banish',
+    ['Holy'] = 'Holy', ['Holy II'] = 'Holy',
+    ['Repose'] = 'Repose',
+    ['Enlight'] = 'Enlight', ['Enlight II'] = 'Enlight',
+    --  Enfeebling Magic: Light
+    ['Addle'] = 'Addle',
+    ['Dia'] = 'Dia', ['Dia II'] = 'Dia', ['Dia III'] = 'Dia', ['Diaga'] = 'Diaga', ['Diaga II'] = 'Diaga',
+    ['Inundation'] = 'Inundation',
+    ['Paralyze'] = 'Paralyze', ['Paralyze II'] = 'Paralyze',
+    ['Slow'] = 'Slow', ['Slow II'] = 'Slow',
+    ['Silence'] = 'Silence',
+    --  Enfeebling Magic: Dark
+    ['Bind'] = 'Bind',
+    ['Blind'] = 'Blind', ['Blind II'] = 'Blind',
+    ['Break'] = 'Break',
+    ['Dispel'] = 'Dispel',
+    ['Distract'] = 'Distract', ['Distract II'] = 'Distract', ['Distract III'] = 'Distract',
+    ['Frazzle'] = 'Frazzle', ['Frazzle II'] = 'Frazzle', ['Frazzle III'] = 'Frazzle',
+    ['Gravity'] = 'Gravity', ['Gravity II'] = 'Gravity',
+    ['Poison'] = 'Poison', ['Poison II'] = 'Poison', ['Poisonga'] = 'Poisonga',
+    ['Sleep'] = 'Sleep', ['Sleep II'] = 'Sleep', ['Sleepga'] = 'Sleepga', ['Sleepga II'] = 'Sleepga',
+    --  Healing Magic
+    ['Cure'] = 'Cure', ['Cure II'] = 'Cure', ['Cure III'] = 'Cure', ['Cure IV'] = 'Cure', ['Cure V'] = 'Cure', ['Cure VI'] = 'Cure',
+    ['Full Cure'] = 'Cure',
+    ['Cura'] = 'Curaga', ['Cura II'] = 'Curaga', ['Cura III'] = 'Curaga',
+    ['Curaga'] = 'Curaga', ['Curaga II'] = 'Curaga', ['Curaga III'] = 'Curaga', ['Curaga IV'] = 'Curaga', ['Curaga V'] = 'Curaga',
+    ['Raise'] = 'Raise', ['Raise II'] = 'Raise', ['Raise III'] = 'Raise', ['Arise'] = 'Raise',
+    --  Status Removal doesn't include Esuna or Sacrifice, since they work differently than the rest
+    ['Poisona'] = 'StatusRemoval', ['Paralyna'] = 'StatusRemoval', ['Silena'] = 'StatusRemoval', ['Blindna'] = 'StatusRemoval', ['Cursna'] = 'StatusRemoval',
+    ['Stona'] = 'StatusRemoval', ['Viruna'] = 'StatusRemoval', ['Erase'] = 'StatusRemoval',
+    --  Enhancing Magic
+    ['Barfire'] = 'BarElement', ['Barstone'] = 'BarElement',  ['Barwater'] = 'BarElement',  ['Baraero'] = 'BarElement', ['Barblizzard'] = 'BarElement', ['Barthunder'] = 'BarElement',
+    ['Barfira'] = 'BarElement', ['Barstonra'] = 'BarElement', ['Barwatera'] = 'BarElement', ['Baraera'] = 'BarElement', ['Barblizzara'] = 'BarElement', ['Barthundra'] = 'BarElement',
+    ['Barsleep'] = 'BarElement',   ['Barblind'] = 'BarElement',   ['Barvirus'] = 'BarElement', ['Baramnesia'] = 'BarElement', ['Barpetrify'] = 'BarElement', ['Barpoison'] = 'BarElement',   ['Barsilence'] = 'BarElement',   ['Barparalyze'] = 'BarElement',
+    ['Barsleepra'] = 'BarElement', ['Barblindra'] = 'BarElement', ['Barvira'] = 'BarElement',  ['Baramnesra'] = 'BarElement', ['Barpetra'] = 'BarElement',   ['Barpoisonra'] = 'BarElement', ['Barsilencera'] = 'BarElement', ['Barparalyzra'] = 'BarElement',
+    ['Reraise'] = 'Reraise', ['Reraise II'] = 'Reraise', ['Reraise III'] = 'Reraise', ['Reraise IV'] = 'Reraise',
+    ['Protect'] = 'Protect',     ['Protect II'] = 'Protect',     ['Protect III'] = 'Protect',     ['Protect IV'] = 'Protect',     ['Protect V'] = 'Protect',
+    ['Protectra'] = 'Protectra', ['Protectra II'] = 'Protectra', ['Protectra III'] = 'Protectra', ['Protectra IV'] = 'Protectra', ['Protectra V'] = 'Protectra',
+    ['Shell'] = 'Shell',     ['Shell II'] = 'Shell',     ['Shell III'] = 'Shell',     ['Shell IV'] = 'Shell',     ['Shell V'] = 'Shell',
+    ['Shellra'] = 'Shellra', ['Shellra II'] = 'Shellra', ['Shellra III'] = 'Shellra', ['Shellra IV'] = 'Shellra', ['Shellra V'] = 'Shellra',
+    ['Regen'] = 'Regen', ['Regen II'] = 'Regen', ['Regen III'] = 'Regen', ['Regen IV'] = 'Regen', ['Regen V'] = 'Regen',
+    ['Refresh'] = 'Refresh', ['Refresh II'] = 'Refresh', ['Refresh III'] = 'Refresh',
+    ['Teleport-Holla'] = 'Teleport', ['Teleport-Dem'] = 'Teleport',   ['Teleport-Mea'] = 'Teleport',
+    ['Teleport-Altep'] = 'Teleport', ['Teleport-Yhoat'] = 'Teleport', ['Teleport-Vahzl'] = 'Teleport',
+    ['Recall-Pashh'] = 'Teleport',   ['Recall-Meriph'] = 'Teleport',  ['Recall-Jugner'] = 'Teleport',
+    ['Firestorm'] = 'Storm',    ['Hailstorm'] = 'Storm',    ['Windstorm'] = 'Storm',    ['Sandstorm'] = 'Storm',    ['Thunderstorm'] = 'Storm',    ['Rainstorm'] = 'Storm',    ['Aurorastorm'] = 'Storm',    ['Voidstorm'] = 'Storm',
+    ['Firestorm II'] = 'Storm', ['Hailstorm II'] = 'Storm', ['Windstorm II'] = 'Storm', ['Sandstorm II'] = 'Storm', ['Thunderstorm II'] = 'Storm', ['Rainstorm II'] = 'Storm', ['Aurorastorm II'] = 'Storm', ['Voidstorm II'] = 'Storm',
+    ['Enstone'] = 'Enspell',    ['Enwater'] = 'Enspell',    ['Enaero'] = 'Enspell',    ['Enfire'] = 'Enspell',    ['Enblizzard'] = 'Enspell',    ['Enthunder'] = 'Enspell',
+    ['Enstone II'] = 'Enspell', ['Enwater II'] = 'Enspell', ['Enaero II'] = 'Enspell', ['Enfire II'] = 'Enspell', ['Enblizzard II'] = 'Enspell', ['Enthunder II'] = 'Enspell',
+    --  Elemental Magic
+    ['Burn'] = 'ElementalEnfeeble', ['Frost'] = 'ElementalEnfeeble', ['Choke'] = 'ElementalEnfeeble', ['Rasp'] = 'ElementalEnfeeble', ['Shock'] = 'ElementalEnfeeble', ['Drown'] = 'ElementalEnfeeble',
+    ['Pyrohelix'] = 'Helix', ['Cryohelix'] = 'Helix', ['Anemohelix'] = 'Helix', ['Geohelix'] = 'Helix', ['Ionohelix'] = 'Helix', ['Hydrohelix'] = 'Helix', ['Luminohelix'] = 'Helix', ['Noctohelix'] = 'Helix',
+    ['Pyrohelix II'] = 'Helix', ['Cryohelix II'] = 'Helix', ['Anemohelix II'] = 'Helix', ['Geohelix II'] = 'Helix', ['Ionohelix II'] = 'Helix', ['Hydrohelix II'] = 'Helix', ['Luminohelix II'] = 'Helix', ['Noctohelix II'] = 'Helix',
+    --  Songs
+    ['Valor Minuet'] = 'Minuet', ['Valor Minuet II'] = 'Minuet', ['Valor Minuet III'] = 'Minuet', ['Valor Minuet IV'] = 'Minuet', ['Valor Minuet V'] = 'Minuet',
+    ["Knight's Minne"] = 'Minne', ["Knight's Minne II"] = 'Minne', ["Knight's Minne III"] = 'Minne', ["Knight's Minne IV"] = 'Minne', ["Knight's Minne V"] = 'Minne',
+    ['Advancing March'] = 'March', ['Victory March'] = 'March',
+    ['Sword Madrigal'] = 'Madrigal', ['Blade Madrigal'] = 'Madrigal',
+    ["Hunter's Prelude"] = 'Prelude', ["Archer's Prelude"] = 'Prelude',
+    ['Sheepfoe Mambo'] = 'Mambo', ['Dragonfoe Mambo'] = 'Mambo',
+    ['Raptor Mazurka'] = 'Mazurka', ['Chocobo Mazurka'] = 'Mazurka',
+    ['Sinewy Etude'] = 'Etude', ['Dextrous Etude'] = 'Etude', ['Vivacious Etude'] = 'Etude', ['Quick Etude'] = 'Etude', ['Learned Etude'] = 'Etude', ['Spirited Etude'] = 'Etude', ['Enchanting Etude'] = 'Etude',
+    ['Herculean Etude'] = 'Etude', ['Uncanny Etude'] = 'Etude', ['Vital Etude'] = 'Etude', ['Swift Etude'] = 'Etude', ['Sage Etude'] = 'Etude', ['Logical Etude'] = 'Etude', ['Bewitching Etude'] = 'Etude',
+    ["Mage's Ballad"] = 'Ballad', ["Mage's Ballad II"] = 'Ballad', ["Mage's Ballad III"] = 'Ballad',
+    ["Army's Paeon"] = 'Paeon', ["Army's Paeon II"] = 'Paeon', ["Army's Paeon III"] = 'Paeon', ["Army's Paeon IV"] = 'Paeon', ["Army's Paeon V"] = 'Paeon', ["Army's Paeon VI"] = 'Paeon',
+    ['Fire Carol'] = 'Carol', ['Ice Carol'] = 'Carol', ['Wind Carol'] = 'Carol', ['Earth Carol'] = 'Carol', ['Lightning Carol'] = 'Carol', ['Water Carol'] = 'Carol', ['Light Carol'] = 'Carol', ['Dark Carol'] = 'Carol',
+    ['Fire Carol II'] = 'Carol', ['Ice Carol II'] = 'Carol', ['Wind Carol II'] = 'Carol', ['Earth Carol II'] = 'Carol', ['Lightning Carol II'] = 'Carol', ['Water Carol II'] = 'Carol', ['Light Carol II'] = 'Carol', ['Dark Carol II'] = 'Carol',
+    ['Foe Lullaby'] = 'Lullaby', ['Foe Lullaby II'] = 'Lullaby', ['Horde Lullaby'] = 'Lullaby', ['Horde Lullaby II'] = 'Lullaby',
+    ['Fire Threnody'] = 'Threnody', ['Ice Threnody'] = 'Threnody', ['Wind Threnody'] = 'Threnody', ['Earth Threnody'] = 'Threnody', ['Lightning Threnody'] = 'Threnody', ['Water Threnody'] = 'Threnody', ['Light Threnody'] = 'Threnody', ['Dark Threnody'] = 'Threnody',
+    ['Fire Threnody II'] = 'Threnody', ['Ice Threnody II'] = 'Threnody', ['Wind Threnody II'] = 'Threnody', ['Earth Threnody II'] = 'Threnody', ['Lightning Threnody II'] = 'Threnody', ['Water Threnody II'] = 'Threnody', ['Light Threnody II'] = 'Threnody', ['Dark Threnody II'] = 'Threnody',
+    ['Battlefield Elegy'] = 'Elegy', ['Carnage Elegy'] = 'Elegy',
+    ['Foe Requiem'] = 'Requiem', ['Foe Requiem II'] = 'Requiem', ['Foe Requiem III'] = 'Requiem', ['Foe Requiem IV'] = 'Requiem', ['Foe Requiem V'] = 'Requiem', ['Foe Requiem VI'] = 'Requiem', ['Foe Requiem VII'] = 'Requiem',
+    --  Ninjutsu
+    ['Utsusemi: Ichi'] = 'Utsusemi', ['Utsusemi: Ni'] = 'Utsusemi', ['Utsusemi: San'] = 'Utsusemi',
+    ['Katon: Ichi'] = 'ElementalNinjutsu', ['Suiton: Ichi'] = 'ElementalNinjutsu', ['Raiton: Ichi'] = 'ElementalNinjutsu',
+    ['Doton: Ichi'] = 'ElementalNinjutsu', ['Huton: Ichi'] = 'ElementalNinjutsu', ['Hyoton: Ichi'] = 'ElementalNinjutsu',
+    ['Katon: Ni'] = 'ElementalNinjutsu', ['Suiton: Ni'] = 'ElementalNinjutsu', ['Raiton: Ni'] = 'ElementalNinjutsu',
+    ['Doton: Ni'] = 'ElementalNinjutsu', ['Huton: Ni'] = 'ElementalNinjutsu', ['Hyoton: Ni'] = 'ElementalNinjutsu',
+    ['Katon: San'] = 'ElementalNinjutsu', ['Suiton: San'] = 'ElementalNinjutsu', ['Raiton: San'] = 'ElementalNinjutsu',
+    ['Doton: San'] = 'ElementalNinjutsu', ['Huton: San'] = 'ElementalNinjutsu', ['Hyoton: San'] = 'ElementalNinjutsu',
+    --  Puppetmaster Maneuvers
+    ['Fire Maneuver'] = 'Maneuver', ['Ice Maneuver'] = 'Maneuver', ['Wind Maneuver'] = 'Maneuver', ['Earth Maneuver'] = 'Maneuver', ['Thunder Maneuver'] = 'Maneuver',
+    ['Water Maneuver'] = 'Maneuver', ['Light Maneuver'] = 'Maneuver', ['Dark Maneuver'] = 'Maneuver',
 }
 
-no_skill_spells_list = S{'Haste', 'Refresh', 'Regen', 'Protect', 'Protectra', 'Shell', 'Shellra',
-        'Raise', 'Reraise', 'Sneak', 'Invisible', 'Deodorize'}
+no_skill_spells_list = S{
+    'Haste', 'Refresh', 'Regen', 'Protect', 'Protectra', 'Shell', 'Shellra',
+    'Raise', 'Reraise', 'Sneak', 'Invisible', 'Deodorize'
+}
 
 
 -------------------------------------------------------------------------------------------------------------------
@@ -245,6 +318,7 @@ areas.Cities = S{
     "Rabao",
     "Chocobo Circuit",
 }
+
 -- Adoulin areas, where Ionis will grant special stat bonuses.
 areas.Adoulin = S{
     "Yahse Hunting Grounds",

--- a/Varrout_DRK.lua
+++ b/Varrout_DRK.lua
@@ -263,8 +263,4 @@ end
 function select_default_macro_book(isSubJobChange)
     -- Default macro set/book
     set_macro_page(1, 8)
-
-    if not isSubJobChange then
-        -- randomise_lockstyle()
-    end
 end

--- a/Varrout_RDM.lua
+++ b/Varrout_RDM.lua
@@ -17,38 +17,39 @@ toau_zones = S{
 }
 
 enfeebling_int = S{
+    "Bind",
     "Blind",
     "Blind II",
-    "Poison",
-    "Poison II",
-    "Sleep",
-    "SLeep II",
-    "Sleepga",
     "Break",
-    "Bind",
     "Dispel",
-    "Gravity",
-    "Gravity II",
     "Distract",
     "Distract II",
     "Distract III",
     "Frazzle",
     "Frazzle II",
-    "Frazzle III"
+    "Frazzle III",
+    "Gravity",
+    "Gravity II",
+    "Poison",
+    "Poison II",
+    "Poisonga",
+    "Sleep",
+    "Sleep II",
+    "Sleepga",
 }
 
 enfeebling_mnd = S{
-    "Slow",
-    "Slow II",
-    "Paralyze",
-    "Paralyze II",
+    "Addle",
     "Dia",
     "Dia II",
     "Dia III",
     "Diaga",
+    "Inundation",
+    "Paralyze",
+    "Paralyze II",
+    "Slow",
+    "Slow II",
     "Silence",
-    "Addle",
-    "Inundation"
 }
 
 -- Initialization function for this job file.
@@ -58,12 +59,13 @@ function get_sets()
     -- Load and initialize the include file.
     include('Mote-Include.lua')
     include('common_lists.lua')
+    include('common_functions.lua')
 end
 
 
 -- Setup vars that are user-independent.  state.Buff vars initialized here will automatically be tracked.
 function job_setup()
-    state.Buff.Saboteur = buffactive.saboteur or false
+    -- state.Buff.Saboteur = buffactive.saboteur or false
 end
 
 -------------------------------------------------------------------------------------------------------------------
@@ -322,7 +324,7 @@ function init_gear_sets()
         body        = "Jhakri Robe +2",
         hands       = { name="Chironic Gloves", augments={'"Mag.Atk.Bns."+9','Attack+1','"Refresh"+1','Accuracy+13 Attack+13','Mag. Acc.+7 "Mag.Atk.Bns."+7',}},
         legs        = { name="Chironic Hose", augments={'INT+5','Enmity-3','"Refresh"+1','Accuracy+11 Attack+11',}},
-        feet        = { name="Chironic Slippers", augments={'Mag. Acc.+12','"Fast Cast"+3','"Refresh"+1','Mag. Acc.+2 "Mag.Atk.Bns."+2',}},
+        feet        = "Chironic Slippers",
         neck        = "Sanctity Necklace",
         waist       = "Fucho-no-Obi",
         left_ear    = { name="Moonshade Earring", augments={'MP+25','Latent effect: "Refresh"+1',}},

--- a/Varrout_SMN.lua
+++ b/Varrout_SMN.lua
@@ -175,8 +175,9 @@ function init_gear_sets()
         head="Glyphic Horn",          --BP -7
         body="Glyphic Doublet +1",    --BP2 -2
         hands="Glyphic Bracers",      --BP -5
-        legs="Glyphic Spats",         --BP -5
---        feet="Glyphic Pigaches"     --BP -5
+        legs="Glyphic Spats +1",      --BP -5
+        feet="Glyphic Pigaches +1",   --BP -5
+        back="Conveyance Cape",
     }
 
     sets.precast.BloodPactRage = sets.precast.BloodPactWard
@@ -188,12 +189,12 @@ function init_gear_sets()
         sub="Clerisy Strap",        -- FC +2%
         head="Revealer's Crown",    -- FC +5%
         ear1="Loquac. Earring",     -- FC +2%
-        ear2="Etiolation Earring", -- FC +1%
+        ear2="Etiolation Earring",  -- FC +1%
         body="Inyanga Jubbah +2",   -- FC +14%
         hands="Telchine Gloves",    -- FC +2%
         ring1="Kishar Ring",        -- FC +4%
-        ring2="Lebeche Ring",    -- Quick Magic +2%
-        back="Perimede Cape",    -- Quick Magic +4%
+        ring2="Lebeche Ring",       -- Quick Magic +2%
+        back="Perimede Cape",       -- Quick Magic +4%
         waist="Witful Belt",        -- FC +3%
         legs="Orvail Pants +1",     -- FC +5%
         feet="Chelona Boots"        -- FC +4%

--- a/Varrout_WHM.lua
+++ b/Varrout_WHM.lua
@@ -123,7 +123,7 @@ function init_gear_sets()
         neck       = "Loricate Torque +1",
         left_ear   = "Infused Earring",
         right_ear  = "Moonshade Earring",
-        body       = "Theophany Briault +3",
+        body       = "Theophany Bliaut +3",
         hands      = "Inyanga Dastanas +2",
         left_ring  = "Defending Ring",
         right_ring = "Inyanga Ring",
@@ -159,7 +159,7 @@ function init_gear_sets()
 --  AF/Relic JA Sets
 --  --------------------
     sets.precast["Devotion"]    = { head = "Piety Cap +3" }
-    sets.precast["Benediction"] = { body = "Piety Briault +3" }
+    sets.precast["Benediction"] = { body = "Piety Bliaut +3" }
 
     sets.precast.FC = {
         main       = "Oranyan",                            -- FC +10%
@@ -229,7 +229,7 @@ function init_gear_sets()
         ammo       = "Quartz Tathlum +1",
         head       = { name     = "Vanya Hood",
                        augments = {'Healing magic skill +20','"Cure" spellcasting time -7%','Magic dmg. taken -3',}},
-        body       = "Theo. Briault +3",
+        body       = "Theo. Bliaut +3",
         hands      = "Theophany Mitts +3",
         legs       = "Ebers Pant. +1",
         feet       = { name     = "Vanya Clogs",
@@ -250,7 +250,7 @@ function init_gear_sets()
         ammo       = "Quartz Tathlum +1",
         head       = { name     = "Vanya Hood",
                        augments = {'Healing magic skill +20','"Cure" spellcasting time -7%','Magic dmg. taken -3',}},
-        body       = "Theo. Briault +3",
+        body       = "Theo. Bliaut +3",
         hands      = "Theophany Mitts +3",
         legs       = "Ebers Pant. +1",
         feet       = { name     = "Vanya Clogs",
@@ -339,7 +339,7 @@ function init_gear_sets()
     sets.midcast['Regen'] = set_combine(sets.midcast['Enhancing Magic'], {
         main       = "Bolelabunga",                 --  Regen Potency +10%
         head       = "Inyanga Tiara +2",            --  Regen Potency +14%
-        body       = "Piety Briault +3",            --  Regen Potency +52%
+        body       = "Piety Bliaut +3",            --  Regen Potency +52%
         hands      = "Ebers Mitts +1",              --  Regen Duration +22
         legs       = "Theophany Pantaloons +3"      --  Regen Duration +24
     })
@@ -388,7 +388,7 @@ function init_gear_sets()
     }
 
     sets.midcast['Enfeebling Magic'] = set_combine(sets.midcast.MagicAcc, {
-        body       = "Theophany Briault +3",
+        body       = "Theophany Bliaut +3",
         right_ring = "Kishar Ring",
         waist      = "Casso Sash",
         legs       = { name     = "Chironic Hose",
@@ -418,7 +418,7 @@ function init_gear_sets()
 
     sets.melee.Engaged = {
         head       = "Theophany Cap +3",
-        body       = "Theo. Briault +3",
+        body       = "Theo. Bliaut +3",
         hands      = "Theophany Mitts +3",
         legs       = "Th. Pant. +3",
         feet       = "Theo. Duckbills +3",


### PR DESCRIPTION
**Big changes to Mote-Mappings.lua**
All enfeebling magic and enspells have been added to the `Mote-Mappings.lua` file to assist with RDM spell casting.  Took me a while to figure out what was going wrong here.  I guess this hasn't been updated for a while or wasn't intended to track these spells?

**Other**
Updates to the `.lua` files for
- RDM
Changed enfeebling spell lists to be in alphabetical order
Removed extra buffs on Chironic Slippers.  This will need to be updated again.
- SMN
Misc whitespace changes
- DRK
Removed `randomise_lockstyle()` from `select_default_macro_book()`
- WHM
Briault -> Bliaut